### PR TITLE
State Space Obfuscation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /B_ICC2012_preliminary_all_cell/signal.rc
 /B_ICC2012_preliminary_all_cell/tsmc13.v
 /B_ICC2012_preliminary_all_cell/NFC_syn.sdf.X
+
+/B_ICC2012_preliminary_all_cell/synopsys_dc.setup

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /B_ICC2012_preliminary_all_cell/NFC_syn.sdf.X
 
 /B_ICC2012_preliminary_all_cell/synopsys_dc.setup
+/B_ICC2012_preliminary_all_cell/fsdb2vcdLog

--- a/B_ICC2012_preliminary_all_cell/NFC.v
+++ b/B_ICC2012_preliminary_all_cell/NFC.v
@@ -1,5 +1,5 @@
 `timescale 1ns/100ps
-module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B, KEY);
+module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B);
     input clk;
     input rst;
     output reg done;
@@ -17,23 +17,6 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
     output reg F_REN_B;
     output reg F_WEN_B;
     input  F_RB_B;
-
-    input [3:0] KEY;
-
-
-    /*============KEY Wire===========*/
-    localparam OFSM_KEY_0 = 4'h5;   //P
-    localparam OFSM_KEY_1 = 4'h0;
-    localparam OFSM_KEY_2 = 4'h5;   //Y
-    localparam OFSM_KEY_3 = 4'h9;
-    localparam OFSM_KEY_4 = 4'h5;   //P
-    localparam OFSM_KEY_5 = 4'h0;
-    localparam OFSM_KEY_6 = 4'h4;   //D
-    localparam OFSM_KEY_7 = 4'h4;
-    localparam WTMK_KEY = 4'b1111;
-    reg WTMK_ACTIVE;
-    wire KEY_CORRECT;
-    wire KEY_WARTERMARK;
  
     /*========F_IO_A Tristate========*/
     wire [7:0] F_IO_A_IN;
@@ -55,182 +38,54 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
     /*===============================*/
 
 
-    reg [4:0] state;
+    reg [3:0] state;
     reg [8:0] page;     //Total of 512 pages, 9 bit.
     reg [8:0] counter;  //Count 512.
 
-
-    /*
-    WARTERMARK: "PY Party"
-    MD5:        "583ca420301785991e99345de37d4c5d"
-    */
-
     /*=============FSM States=============*/
-    localparam STATE_READ_COMMAND_0 = 5'd0;
-    localparam STATE_READ_COMMAND_1 = 5'd1;
-    localparam STATE_READ_ADDRESS_0 = 5'd2;
-    localparam STATE_READ_ADDRESS_1 = 5'd3;
-    localparam STATE_READ_ADDRESS_2 = 5'd4;
-    localparam STATE_READ_ADDRESS_3 = 5'd5;
-    localparam STATE_READ_ADDRESS_4 = 5'd6;
-    localparam STATE_READ_ADDRESS_5 = 5'd7;
-    localparam STATE_READ_READING_0 = 5'd8;
-    localparam STATE_READ_READING_1 = 5'd9;
-    localparam STATE_READ_BUSYING_0 = 5'd10;
-    localparam STATE_READ_BUSYING_1 = 5'd11;
-    localparam OBFUS_AUTH_0  = 5'd16;
-    localparam OBFUS_AUTH_1  = 5'd17;
-    localparam OBFUS_AUTH_2  = 5'd18;
-    localparam OBFUS_AUTH_3  = 5'd19;
-    localparam OBFUS_AUTH_4  = 5'd20;
-    localparam OBFUS_AUTH_5  = 5'd21;
-    localparam OBFUS_AUTH_6  = 5'd22;
-    localparam OBFUS_AUTH_7  = 5'd23;
-    localparam OBFUS_DUMY_0  = 5'd24;
-    localparam OBFUS_DUMY_1  = 5'd25;
-    localparam OBFUS_DUMY_2  = 5'd26;
-    localparam OBFUS_DUMY_3  = 5'd27;
-    localparam OBFUS_DUMY_4  = 5'd28;
-    localparam OBFUS_DUMY_5  = 5'd29;
-    localparam OBFUS_DUMY_6  = 5'd30;
-    localparam OBFUS_DUMY_7  = 5'd31;
+    localparam STATE_READ_COMMAND_0 = 4'd0;
+    localparam STATE_READ_COMMAND_1 = 4'd1;
+    localparam STATE_READ_ADDRESS_0 = 4'd2;
+    localparam STATE_READ_ADDRESS_1 = 4'd3;
+    localparam STATE_READ_ADDRESS_2 = 4'd4;
+    localparam STATE_READ_ADDRESS_3 = 4'd5;
+    localparam STATE_READ_ADDRESS_4 = 4'd6;
+    localparam STATE_READ_ADDRESS_5 = 4'd7;
+    localparam STATE_READ_READING_0 = 4'd8;
+    localparam STATE_READ_READING_1 = 4'd9;
+    localparam STATE_READ_BUSYING_0 = 4'd10;
+    localparam STATE_READ_BUSYING_1 = 4'd11;
     /*====================================*/
     
     always @(posedge clk) begin
         if (rst) begin
             done <= 1'b0;
 
-            // F_IO_A_READING <= 1'b0;
-            // F_IO_B_READING <= 1'b0;
+            F_IO_A_READING <= 1'b0;
+            F_IO_B_READING <= 1'b0;
 
-            // state   <= STATE_READ_COMMAND_0;
-            state   <= OBFUS_AUTH_0;
-            // page    <= 9'd0;
-            // counter <= 9'd0;
+            state   <= STATE_READ_COMMAND_0;
+            page    <= 9'd0;
+            counter <= 9'd0;
 
-            WTMK_ACTIVE <= 0;
+            /*=====A=====*/
+            F_CLE_A <= 1;
+            F_WEN_A <= 0;
+            F_WEN_A <= 0;
+            F_ALE_A <= 0;
+            F_REN_A <= 1;
+            /*===========*/
 
-            // /*=====A=====*/
-            // F_CLE_A <= 1;
-            // F_WEN_A <= 0;
-            // F_WEN_A <= 0;
-            // F_ALE_A <= 0;
-            // F_REN_A <= 1;
-            // /*===========*/
-
-            // /*=====B=====*/
-            // F_CLE_B <= 1;
-            // F_WEN_B <= 0;
-            // F_ALE_B <= 0;
-            // F_REN_B <= 1;
-            // /*===========*/
+            /*=====B=====*/
+            F_CLE_B <= 1;
+            F_WEN_B <= 0;
+            F_ALE_B <= 0;
+            F_REN_B <= 1;
+            /*===========*/
 
         end
         else begin
             case (state)
-                /*Authentication Region*/
-                OBFUS_AUTH_0: begin
-                    if (KEY == OFSM_KEY_0) begin  //P0
-                        state <= OBFUS_AUTH_1;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_1: begin
-                    if (KEY == OFSM_KEY_1) begin  //P1
-                        state <= OBFUS_AUTH_2;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_2: begin
-                    if (KEY == OFSM_KEY_2) begin  //Y0
-                        state <= OBFUS_AUTH_3;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_3: begin
-                    if (KEY == OFSM_KEY_3) begin  //Y1
-                        state <= OBFUS_AUTH_4;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_4: begin
-                    if (KEY == OFSM_KEY_4) begin  //P0
-                        state <= OBFUS_AUTH_5;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_5: begin
-                    if (KEY == OFSM_KEY_5) begin  //P1
-                        state <= OBFUS_AUTH_6;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_6: begin
-                    if (KEY == OFSM_KEY_6) begin  //D0
-                        state <= OBFUS_AUTH_7;
-                    end
-                    else begin
-                        state <= OBFUS_DUMY_0;
-                    end
-                end
-                OBFUS_AUTH_7: begin
-                    if (KEY == OFSM_KEY_7) begin  //D1
-                        //Reset registers and enter normal region
-                        done <= 1'b0;
-
-                        F_IO_A_READING <= 1'b0;
-                        F_IO_B_READING <= 1'b0;
-
-                        state <= STATE_READ_COMMAND_0;
-                        page    <= 9'd0;
-                        counter <= 9'd0;
-
-                        /*=====A=====*/
-                        F_CLE_A <= 1;
-                        F_WEN_A <= 0;
-                        F_WEN_A <= 0;
-                        F_ALE_A <= 0;
-                        F_REN_A <= 1;
-                        /*===========*/
-
-                        /*=====B=====*/
-                        F_CLE_B <= 1;
-                        F_WEN_B <= 0;
-                        F_ALE_B <= 0;
-                        F_REN_B <= 1;
-                        /*===========*/
-                    end
-                    else begin
-                        if (KEY == WTMK_KEY) begin
-                            //Wartermark mode actived.
-                            state <= OBFUS_AUTH_0;
-                            WTMK_ACTIVE <= 1;
-                        end
-                        else begin
-                            state <= OBFUS_DUMY_0;
-                        end
-                    end
-                end
-                /*Dummy Region*/
-                OBFUS_DUMY_0: begin
-                    state <= OBFUS_DUMY_1;
-                end
-                OBFUS_DUMY_1: begin
-                    state <= OBFUS_DUMY_0;
-                end
-                /*Normal Region*/
                 STATE_READ_COMMAND_0: begin
                     /*=====A=====*/
                     F_CLE_A <= 1;

--- a/B_ICC2012_preliminary_all_cell/NFC.v
+++ b/B_ICC2012_preliminary_all_cell/NFC.v
@@ -22,7 +22,18 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
 
 
     /*============KEY Wire===========*/
+    localparam OFSM_KEY_0 = 4'h5;   //P
+    localparam OFSM_KEY_1 = 4'h0;
+    localparam OFSM_KEY_2 = 4'h5;   //Y
+    localparam OFSM_KEY_3 = 4'h9;
+    localparam OFSM_KEY_4 = 4'h5;   //P
+    localparam OFSM_KEY_5 = 4'h0;
+    localparam OFSM_KEY_6 = 4'h4;   //D
+    localparam OFSM_KEY_7 = 4'h4;
+    localparam WTMK_KEY = 4'b1111;
+    reg WTMK_ACTIVE;
     wire KEY_CORRECT;
+    wire KEY_WARTERMARK;
  
     /*========F_IO_A Tristate========*/
     wire [7:0] F_IO_A_IN;
@@ -75,49 +86,151 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
     localparam OBFUS_AUTH_5  = 5'd21;
     localparam OBFUS_AUTH_6  = 5'd22;
     localparam OBFUS_AUTH_7  = 5'd23;
-    localparam OBFUS_AUTH_8  = 5'd24 
-    localparam OBFUS_AUTH_9  = 5'd25;
-    localparam OBFUS_AUTH_10 = 5'd26;
-    localparam OBFUS_AUTH_11 = 5'd27;
-    localparam OBFUS_AUTH_12 = 5'd28;
-    localparam OBFUS_AUTH_13 = 5'd29;
-    localparam OBFUS_AUTH_14 = 5'd30;
-    localparam OBFUS_AUTH_15 = 5'd31;
+    localparam OBFUS_DUMY_0  = 5'd24;
+    localparam OBFUS_DUMY_1  = 5'd25;
+    localparam OBFUS_DUMY_2  = 5'd26;
+    localparam OBFUS_DUMY_3  = 5'd27;
+    localparam OBFUS_DUMY_4  = 5'd28;
+    localparam OBFUS_DUMY_5  = 5'd29;
+    localparam OBFUS_DUMY_6  = 5'd30;
+    localparam OBFUS_DUMY_7  = 5'd31;
     /*====================================*/
     
     always @(posedge clk) begin
         if (rst) begin
             done <= 1'b0;
 
-            F_IO_A_READING <= 1'b0;
-            F_IO_B_READING <= 1'b0;
+            // F_IO_A_READING <= 1'b0;
+            // F_IO_B_READING <= 1'b0;
 
             // state   <= STATE_READ_COMMAND_0;
             state   <= OBFUS_AUTH_0;
-            page    <= 9'd0;
-            counter <= 9'd0;
+            // page    <= 9'd0;
+            // counter <= 9'd0;
 
-            /*=====A=====*/
-            F_CLE_A <= 1;
-            F_WEN_A <= 0;
-            F_WEN_A <= 0;
-            F_ALE_A <= 0;
-            F_REN_A <= 1;
-            /*===========*/
+            WTMK_ACTIVE <= 0;
 
-            /*=====B=====*/
-            F_CLE_B <= 1;
-            F_WEN_B <= 0;
-            F_ALE_B <= 0;
-            F_REN_B <= 1;
-            /*===========*/
+            // /*=====A=====*/
+            // F_CLE_A <= 1;
+            // F_WEN_A <= 0;
+            // F_WEN_A <= 0;
+            // F_ALE_A <= 0;
+            // F_REN_A <= 1;
+            // /*===========*/
+
+            // /*=====B=====*/
+            // F_CLE_B <= 1;
+            // F_WEN_B <= 0;
+            // F_ALE_B <= 0;
+            // F_REN_B <= 1;
+            // /*===========*/
 
         end
         else begin
             case (state)
+                /*Authentication Region*/
                 OBFUS_AUTH_0: begin
-                    
+                    if (KEY == OFSM_KEY_0) begin  //P0
+                        state <= OBFUS_AUTH_1;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
                 end
+                OBFUS_AUTH_1: begin
+                    if (KEY == OFSM_KEY_1) begin  //P1
+                        state <= OBFUS_AUTH_2;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_2: begin
+                    if (KEY == OFSM_KEY_2) begin  //Y0
+                        state <= OBFUS_AUTH_3;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_3: begin
+                    if (KEY == OFSM_KEY_3) begin  //Y1
+                        state <= OBFUS_AUTH_4;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_4: begin
+                    if (KEY == OFSM_KEY_4) begin  //P0
+                        state <= OBFUS_AUTH_5;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_5: begin
+                    if (KEY == OFSM_KEY_5) begin  //P1
+                        state <= OBFUS_AUTH_6;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_6: begin
+                    if (KEY == OFSM_KEY_6) begin  //D0
+                        state <= OBFUS_AUTH_7;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_7: begin
+                    if (KEY == OFSM_KEY_7) begin  //D1
+                        //Reset registers and enter normal region
+                        done <= 1'b0;
+
+                        F_IO_A_READING <= 1'b0;
+                        F_IO_B_READING <= 1'b0;
+
+                        state <= STATE_READ_COMMAND_0;
+                        page    <= 9'd0;
+                        counter <= 9'd0;
+
+                        /*=====A=====*/
+                        F_CLE_A <= 1;
+                        F_WEN_A <= 0;
+                        F_WEN_A <= 0;
+                        F_ALE_A <= 0;
+                        F_REN_A <= 1;
+                        /*===========*/
+
+                        /*=====B=====*/
+                        F_CLE_B <= 1;
+                        F_WEN_B <= 0;
+                        F_ALE_B <= 0;
+                        F_REN_B <= 1;
+                        /*===========*/
+                    end
+                    else begin
+                        if (KEY == WTMK_KEY) begin
+                            //Wartermark mode actived.
+                            state <= OBFUS_AUTH_0;
+                            WTMK_ACTIVE <= 1;
+                        end
+                        else begin
+                            state <= OBFUS_DUMY_0;
+                        end
+                    end
+                end
+                /*Dummy Region*/
+                OBFUS_DUMY_0: begin
+                    state <= OBFUS_DUMY_1;
+                end
+                OBFUS_DUMY_1: begin
+                    state <= OBFUS_DUMY_0;
+                end
+                /*Normal Region*/
                 STATE_READ_COMMAND_0: begin
                     /*=====A=====*/
                     F_CLE_A <= 1;

--- a/B_ICC2012_preliminary_all_cell/NFC.v
+++ b/B_ICC2012_preliminary_all_cell/NFC.v
@@ -1,5 +1,5 @@
 `timescale 1ns/100ps
-module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B);
+module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B, KEY);
     input clk;
     input rst;
     output reg done;
@@ -17,6 +17,12 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
     output reg F_REN_B;
     output reg F_WEN_B;
     input  F_RB_B;
+
+    input [3:0] KEY;
+
+
+    /*============KEY Wire===========*/
+    wire KEY_CORRECT;
  
     /*========F_IO_A Tristate========*/
     wire [7:0] F_IO_A_IN;
@@ -38,23 +44,45 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
     /*===============================*/
 
 
-    reg [3:0] state;
+    reg [4:0] state;
     reg [8:0] page;     //Total of 512 pages, 9 bit.
     reg [8:0] counter;  //Count 512.
 
+
+    /*
+    WARTERMARK: "PY Party"
+    MD5:        "583ca420301785991e99345de37d4c5d"
+    */
+
     /*=============FSM States=============*/
-    localparam STATE_READ_COMMAND_0 = 4'd0;
-    localparam STATE_READ_COMMAND_1 = 4'd1;
-    localparam STATE_READ_ADDRESS_0 = 4'd2;
-    localparam STATE_READ_ADDRESS_1 = 4'd3;
-    localparam STATE_READ_ADDRESS_2 = 4'd4;
-    localparam STATE_READ_ADDRESS_3 = 4'd5;
-    localparam STATE_READ_ADDRESS_4 = 4'd6;
-    localparam STATE_READ_ADDRESS_5 = 4'd7;
-    localparam STATE_READ_READING_0 = 4'd8;
-    localparam STATE_READ_READING_1 = 4'd9;
-    localparam STATE_READ_BUSYING_0 = 4'd10;
-    localparam STATE_READ_BUSYING_1 = 4'd11;
+    localparam STATE_READ_COMMAND_0 = 5'd0;
+    localparam STATE_READ_COMMAND_1 = 5'd1;
+    localparam STATE_READ_ADDRESS_0 = 5'd2;
+    localparam STATE_READ_ADDRESS_1 = 5'd3;
+    localparam STATE_READ_ADDRESS_2 = 5'd4;
+    localparam STATE_READ_ADDRESS_3 = 5'd5;
+    localparam STATE_READ_ADDRESS_4 = 5'd6;
+    localparam STATE_READ_ADDRESS_5 = 5'd7;
+    localparam STATE_READ_READING_0 = 5'd8;
+    localparam STATE_READ_READING_1 = 5'd9;
+    localparam STATE_READ_BUSYING_0 = 5'd10;
+    localparam STATE_READ_BUSYING_1 = 5'd11;
+    localparam OBFUS_AUTH_0  = 5'd16;
+    localparam OBFUS_AUTH_1  = 5'd17;
+    localparam OBFUS_AUTH_2  = 5'd18;
+    localparam OBFUS_AUTH_3  = 5'd19;
+    localparam OBFUS_AUTH_4  = 5'd20;
+    localparam OBFUS_AUTH_5  = 5'd21;
+    localparam OBFUS_AUTH_6  = 5'd22;
+    localparam OBFUS_AUTH_7  = 5'd23;
+    localparam OBFUS_AUTH_8  = 5'd24 
+    localparam OBFUS_AUTH_9  = 5'd25;
+    localparam OBFUS_AUTH_10 = 5'd26;
+    localparam OBFUS_AUTH_11 = 5'd27;
+    localparam OBFUS_AUTH_12 = 5'd28;
+    localparam OBFUS_AUTH_13 = 5'd29;
+    localparam OBFUS_AUTH_14 = 5'd30;
+    localparam OBFUS_AUTH_15 = 5'd31;
     /*====================================*/
     
     always @(posedge clk) begin
@@ -64,7 +92,8 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
             F_IO_A_READING <= 1'b0;
             F_IO_B_READING <= 1'b0;
 
-            state   <= STATE_READ_COMMAND_0;
+            // state   <= STATE_READ_COMMAND_0;
+            state   <= OBFUS_AUTH_0;
             page    <= 9'd0;
             counter <= 9'd0;
 
@@ -86,6 +115,9 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
         end
         else begin
             case (state)
+                OBFUS_AUTH_0: begin
+                    
+                end
                 STATE_READ_COMMAND_0: begin
                     /*=====A=====*/
                     F_CLE_A <= 1;

--- a/B_ICC2012_preliminary_all_cell/NFC_KEY.v
+++ b/B_ICC2012_preliminary_all_cell/NFC_KEY.v
@@ -99,37 +99,56 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
     always @(posedge clk) begin
         if (rst) begin
             done <= 1'b0;
-
-            // F_IO_A_READING <= 1'b0;
-            // F_IO_B_READING <= 1'b0;
-
-            // state   <= STATE_READ_COMMAND_0;
             state   <= OBFUS_AUTH_0;
-            // page    <= 9'd0;
-            // counter <= 9'd0;
-
             WTMK_ACTIVE <= 0;
 
-            // /*=====A=====*/
-            // F_CLE_A <= 1;
-            // F_WEN_A <= 0;
-            // F_WEN_A <= 0;
-            // F_ALE_A <= 0;
-            // F_REN_A <= 1;
-            // /*===========*/
+            F_IO_A_READING <= 1'bX;
+            F_IO_B_READING <= 1'bX;
 
-            // /*=====B=====*/
-            // F_CLE_B <= 1;
-            // F_WEN_B <= 0;
-            // F_ALE_B <= 0;
-            // F_REN_B <= 1;
-            // /*===========*/
+            page    <= 9'bX;
+            counter <= 9'bX;
+
+            /*=====A=====*/
+            F_CLE_A <= 1'bX;
+            F_WEN_A <= 1'bX;
+            F_WEN_A <= 1'bX;
+            F_ALE_A <= 1'bX;
+            F_REN_A <= 1'bX;
+            /*===========*/
+
+            /*=====B=====*/
+            F_CLE_B <= 1'bX;
+            F_WEN_B <= 1'bX;
+            F_ALE_B <= 1'bX;
+            F_REN_B <= 1'bX;
+            /*===========*/
+            
 
         end
         else begin
             case (state)
                 /*Authentication Region*/
                 OBFUS_AUTH_0: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_0) begin  //P0
                         state <= OBFUS_AUTH_1;
                     end
@@ -138,6 +157,26 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
                     end
                 end
                 OBFUS_AUTH_1: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_1) begin  //P1
                         state <= OBFUS_AUTH_2;
                     end
@@ -146,6 +185,26 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
                     end
                 end
                 OBFUS_AUTH_2: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_2) begin  //Y0
                         state <= OBFUS_AUTH_3;
                     end
@@ -154,6 +213,26 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
                     end
                 end
                 OBFUS_AUTH_3: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_3) begin  //Y1
                         state <= OBFUS_AUTH_4;
                     end
@@ -162,6 +241,26 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
                     end
                 end
                 OBFUS_AUTH_4: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_4) begin  //P0
                         state <= OBFUS_AUTH_5;
                     end
@@ -170,6 +269,26 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
                     end
                 end
                 OBFUS_AUTH_5: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_5) begin  //P1
                         state <= OBFUS_AUTH_6;
                     end
@@ -178,6 +297,26 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
                     end
                 end
                 OBFUS_AUTH_6: begin
+                    F_IO_A_READING <= 1'bX;
+                    F_IO_B_READING <= 1'bX;
+
+                    page    <= 9'bX;
+                    counter <= 9'bX;
+
+                    /*=====A=====*/
+                    F_CLE_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_WEN_A <= 1'bX;
+                    F_ALE_A <= 1'bX;
+                    F_REN_A <= 1'bX;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1'bX;
+                    F_WEN_B <= 1'bX;
+                    F_ALE_B <= 1'bX;
+                    F_REN_B <= 1'bX;
+                    /*===========*/
                     if (KEY == OFSM_KEY_6) begin  //D0
                         state <= OBFUS_AUTH_7;
                     end
@@ -457,7 +596,7 @@ module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F
 
 
     always @(*) begin
-        if (rst) begin
+        if (rst | (state == OBFUS_AUTH_7)) begin
             F_IO_A_OUT = 8'h00; //Here we use h00 instead of h01 is because we want to start at first half page.
             F_IO_B_OUT = 8'h80;
         end

--- a/B_ICC2012_preliminary_all_cell/NFC_KEY.v
+++ b/B_ICC2012_preliminary_all_cell/NFC_KEY.v
@@ -1,0 +1,502 @@
+`timescale 1ns/100ps
+module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B, KEY);
+    input clk;
+    input rst;
+    output reg done;
+
+    inout [7:0] F_IO_A;
+    output reg F_CLE_A;
+    output reg F_ALE_A;
+    output reg F_REN_A;
+    output reg F_WEN_A;
+    input  F_RB_A;
+
+    inout [7:0] F_IO_B;
+    output reg F_CLE_B;
+    output reg F_ALE_B;
+    output reg F_REN_B;
+    output reg F_WEN_B;
+    input  F_RB_B;
+
+    input [3:0] KEY;
+
+
+    /*============KEY Wire===========*/
+    localparam OFSM_KEY_0 = 4'h5;   //P
+    localparam OFSM_KEY_1 = 4'h0;
+    localparam OFSM_KEY_2 = 4'h5;   //Y
+    localparam OFSM_KEY_3 = 4'h9;
+    localparam OFSM_KEY_4 = 4'h5;   //P
+    localparam OFSM_KEY_5 = 4'h0;
+    localparam OFSM_KEY_6 = 4'h4;   //D
+    localparam OFSM_KEY_7 = 4'h4;
+    localparam WTMK_KEY = 4'b1111;
+    reg WTMK_ACTIVE;
+    wire KEY_CORRECT;
+    wire KEY_WARTERMARK;
+ 
+    /*========F_IO_A Tristate========*/
+    wire [7:0] F_IO_A_IN;
+    reg  [7:0] F_IO_A_OUT;
+    reg        F_IO_A_READING;
+
+    assign F_IO_A = F_IO_A_READING ? 8'hZZ : F_IO_A_OUT;
+    // assign F_IO_A_IN = F_IO_A;
+    /*===============================*/
+
+
+    /*========F_IO_B Tristate========*/
+    wire [7:0] F_IO_B_IN;
+    reg  [7:0] F_IO_B_OUT;
+    reg        F_IO_B_READING;
+
+    assign F_IO_B = F_IO_B_READING ? 8'hZZ : F_IO_B_OUT;
+    // assign F_IO_B_IN = F_IO_B;
+    /*===============================*/
+
+
+    reg [4:0] state;
+    reg [8:0] page;     //Total of 512 pages, 9 bit.
+    reg [8:0] counter;  //Count 512.
+
+
+    /*
+    WARTERMARK: "PY Party"
+    MD5:        "583ca420301785991e99345de37d4c5d"
+    */
+
+    /*=============FSM States=============*/
+    localparam STATE_READ_COMMAND_0 = 5'd0;
+    localparam STATE_READ_COMMAND_1 = 5'd1;
+    localparam STATE_READ_ADDRESS_0 = 5'd2;
+    localparam STATE_READ_ADDRESS_1 = 5'd3;
+    localparam STATE_READ_ADDRESS_2 = 5'd4;
+    localparam STATE_READ_ADDRESS_3 = 5'd5;
+    localparam STATE_READ_ADDRESS_4 = 5'd6;
+    localparam STATE_READ_ADDRESS_5 = 5'd7;
+    localparam STATE_READ_READING_0 = 5'd8;
+    localparam STATE_READ_READING_1 = 5'd9;
+    localparam STATE_READ_BUSYING_0 = 5'd10;
+    localparam STATE_READ_BUSYING_1 = 5'd11;
+    localparam OBFUS_AUTH_0  = 5'd16;
+    localparam OBFUS_AUTH_1  = 5'd17;
+    localparam OBFUS_AUTH_2  = 5'd18;
+    localparam OBFUS_AUTH_3  = 5'd19;
+    localparam OBFUS_AUTH_4  = 5'd20;
+    localparam OBFUS_AUTH_5  = 5'd21;
+    localparam OBFUS_AUTH_6  = 5'd22;
+    localparam OBFUS_AUTH_7  = 5'd23;
+    localparam OBFUS_DUMY_0  = 5'd24;
+    localparam OBFUS_DUMY_1  = 5'd25;
+    localparam OBFUS_DUMY_2  = 5'd26;
+    localparam OBFUS_DUMY_3  = 5'd27;
+    localparam OBFUS_DUMY_4  = 5'd28;
+    localparam OBFUS_DUMY_5  = 5'd29;
+    localparam OBFUS_DUMY_6  = 5'd30;
+    localparam OBFUS_DUMY_7  = 5'd31;
+    /*====================================*/
+    
+    always @(posedge clk) begin
+        if (rst) begin
+            done <= 1'b0;
+
+            // F_IO_A_READING <= 1'b0;
+            // F_IO_B_READING <= 1'b0;
+
+            // state   <= STATE_READ_COMMAND_0;
+            state   <= OBFUS_AUTH_0;
+            // page    <= 9'd0;
+            // counter <= 9'd0;
+
+            WTMK_ACTIVE <= 0;
+
+            // /*=====A=====*/
+            // F_CLE_A <= 1;
+            // F_WEN_A <= 0;
+            // F_WEN_A <= 0;
+            // F_ALE_A <= 0;
+            // F_REN_A <= 1;
+            // /*===========*/
+
+            // /*=====B=====*/
+            // F_CLE_B <= 1;
+            // F_WEN_B <= 0;
+            // F_ALE_B <= 0;
+            // F_REN_B <= 1;
+            // /*===========*/
+
+        end
+        else begin
+            case (state)
+                /*Authentication Region*/
+                OBFUS_AUTH_0: begin
+                    if (KEY == OFSM_KEY_0) begin  //P0
+                        state <= OBFUS_AUTH_1;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_1: begin
+                    if (KEY == OFSM_KEY_1) begin  //P1
+                        state <= OBFUS_AUTH_2;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_2: begin
+                    if (KEY == OFSM_KEY_2) begin  //Y0
+                        state <= OBFUS_AUTH_3;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_3: begin
+                    if (KEY == OFSM_KEY_3) begin  //Y1
+                        state <= OBFUS_AUTH_4;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_4: begin
+                    if (KEY == OFSM_KEY_4) begin  //P0
+                        state <= OBFUS_AUTH_5;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_5: begin
+                    if (KEY == OFSM_KEY_5) begin  //P1
+                        state <= OBFUS_AUTH_6;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_6: begin
+                    if (KEY == OFSM_KEY_6) begin  //D0
+                        state <= OBFUS_AUTH_7;
+                    end
+                    else begin
+                        state <= OBFUS_DUMY_0;
+                    end
+                end
+                OBFUS_AUTH_7: begin
+                    if (KEY == OFSM_KEY_7) begin  //D1
+                        //Reset registers and enter normal region
+                        done <= 1'b0;
+
+                        F_IO_A_READING <= 1'b0;
+                        F_IO_B_READING <= 1'b0;
+
+                        state <= STATE_READ_COMMAND_0;
+                        page    <= 9'd0;
+                        counter <= 9'd0;
+
+                        /*=====A=====*/
+                        F_CLE_A <= 1;
+                        F_WEN_A <= 0;
+                        F_WEN_A <= 0;
+                        F_ALE_A <= 0;
+                        F_REN_A <= 1;
+                        /*===========*/
+
+                        /*=====B=====*/
+                        F_CLE_B <= 1;
+                        F_WEN_B <= 0;
+                        F_ALE_B <= 0;
+                        F_REN_B <= 1;
+                        /*===========*/
+                    end
+                    else begin
+                        if (KEY == WTMK_KEY) begin
+                            //Wartermark mode actived.
+                            state <= OBFUS_AUTH_0;
+                            WTMK_ACTIVE <= 1;
+                        end
+                        else begin
+                            state <= OBFUS_DUMY_0;
+                        end
+                    end
+                end
+                /*Dummy Region*/
+                OBFUS_DUMY_0: begin
+                    state <= OBFUS_DUMY_1;
+                end
+                OBFUS_DUMY_1: begin
+                    state <= OBFUS_DUMY_0;
+                end
+                /*Normal Region*/
+                STATE_READ_COMMAND_0: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 1;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 0;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_COMMAND_1;
+                end
+                STATE_READ_COMMAND_1: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_0;
+                end
+                STATE_READ_ADDRESS_0: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_1;
+                end
+                STATE_READ_ADDRESS_1: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_2;
+                end
+                STATE_READ_ADDRESS_2: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_3;
+                end
+                STATE_READ_ADDRESS_3: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_4;
+                end
+                STATE_READ_ADDRESS_4: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_5;
+                end
+                STATE_READ_ADDRESS_5: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 0;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    F_IO_A_READING <= 1;
+                    F_IO_B_READING <= 0;
+
+                    state <= STATE_READ_READING_0;
+                end
+                STATE_READ_READING_0: begin
+                    if (F_RB_A && F_REN_A) begin
+                        F_REN_A <= 0;
+                        F_WEN_B <= 0;
+                    end
+                    else begin
+                        if (F_WEN_B) begin
+                            F_REN_A <= 1;
+                            counter <= counter + 1;
+                            if (counter == 9'd511) begin
+                                F_CLE_A <= 1;
+                                F_WEN_A <= 0;
+                                F_IO_A_READING <= 0;
+                                state <= STATE_READ_READING_1;
+                            end
+                            else begin
+
+                            end
+                        end
+                        else begin
+
+                        end
+                        F_WEN_B <= 1;
+                    end
+                end
+                STATE_READ_READING_1: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 1;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 0;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_BUSYING_0;
+                end
+                STATE_READ_BUSYING_0: begin
+                    /*=====B=====*/
+                    F_CLE_B <= 1;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+                    if (!F_RB_B) begin
+                        state <= STATE_READ_BUSYING_1;
+                    end
+                end
+                STATE_READ_BUSYING_1: begin
+                    if (F_RB_B) begin
+                        /*=====B=====*/
+                        F_CLE_B <= 1;
+                        F_WEN_B <= 0;
+                        F_ALE_B <= 0;
+                        F_REN_B <= 1;
+                        /*===========*/
+
+                        page <= page + 1;
+                        if (page == 9'd511) begin
+                            done <= 1;
+                        end
+
+                        state <= STATE_READ_COMMAND_0;
+                    end
+                    else begin
+                        /*=====B=====*/
+                        F_CLE_B <= 0;
+                        F_WEN_B <= 1;
+                        F_ALE_B <= 0;
+                        F_REN_B <= 1;
+                        /*===========*/
+                    end
+                end
+                default: begin
+
+                end
+            endcase
+        end
+    end
+
+
+    always @(*) begin
+        if (rst) begin
+            F_IO_A_OUT = 8'h00; //Here we use h00 instead of h01 is because we want to start at first half page.
+            F_IO_B_OUT = 8'h80;
+        end
+        else begin
+            case (state[3:1])
+                STATE_READ_COMMAND_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    F_IO_B_OUT = 8'h80;
+                end
+                STATE_READ_ADDRESS_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    F_IO_B_OUT = 8'h00;
+                end
+                STATE_READ_ADDRESS_2[3:1]: begin
+                    F_IO_A_OUT = page[7:0];
+                    F_IO_B_OUT = page[7:0];
+                end
+                STATE_READ_ADDRESS_4[3:1]: begin
+                    F_IO_A_OUT = {7'b0, page[8]};
+                    F_IO_B_OUT = {7'b0, page[8]};
+                end
+                STATE_READ_READING_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    if (state[0]) begin
+                        F_IO_B_OUT = 8'h10;
+                    end
+                    else begin
+                        F_IO_B_OUT = F_IO_A;
+                    end
+                end
+                STATE_READ_BUSYING_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    F_IO_B_OUT = 8'h10;
+                end
+                default: begin
+                    F_IO_A_OUT = 8'hXX;
+                    F_IO_B_OUT = 8'hXX;
+                end
+            endcase
+        end
+    end
+endmodule

--- a/B_ICC2012_preliminary_all_cell/testfixture.v
+++ b/B_ICC2012_preliminary_all_cell/testfixture.v
@@ -27,6 +27,9 @@ module test;
   wire f_cle_a, f_ale_a, f_ren_a, f_wen_a, f_rb_a;
   wire [7:0] f_io_b;
   wire f_cle_b, f_ale_b, f_ren_b, f_wen_b, f_rb_b;
+  `ifdef KEY
+  reg [3:0] key;
+  `endif
   integer  out_mem [0:262143]; 
   
   reg [18:0] k;
@@ -95,15 +98,47 @@ module test;
     $readmemh (`EXPECT, out_mem);
   end
 
+    /*============KEY===========*/
+    localparam OFSM_KEY_0 = 4'h5;   //P
+    localparam OFSM_KEY_1 = 4'h0;
+    localparam OFSM_KEY_2 = 4'h5;   //Y
+    localparam OFSM_KEY_3 = 4'h9;
+    localparam OFSM_KEY_4 = 4'h5;   //P
+    localparam OFSM_KEY_5 = 4'h0;
+    localparam OFSM_KEY_6 = 4'h4;   //D
+    localparam OFSM_KEY_7 = 4'h4;
+    localparam WTMK_KEY = 4'b1111;
+
   initial begin
     clk = 1'b0;
     rst = 1'b0;
+    `ifdef KEY
+    key = 4'b0;
+    `endif
     n = 0;
     err = 0;
     #3
       rst = 1'b1;
     #15
       rst = 1'b0;
+    `ifdef KEY
+    #2
+    key = OFSM_KEY_0
+    #20
+    key = OFSM_KEY_1
+    #20
+    key = OFSM_KEY_2
+    #20
+    key = OFSM_KEY_3
+    #20
+    key = OFSM_KEY_4
+    #20
+    key = OFSM_KEY_5
+    #20
+    key = OFSM_KEY_6
+    #20
+    key = OFSM_KEY_7
+    `endif
   end
 
   always #duty clk = ~clk;

--- a/B_ICC2012_preliminary_all_cell/testfixture.v
+++ b/B_ICC2012_preliminary_all_cell/testfixture.v
@@ -52,7 +52,11 @@ module test;
           .F_ALE_B(f_ale_b), 
           .F_REN_B(f_ren_b), 
           .F_WEN_B(f_wen_b), 
-          .F_RB_B(f_rb_b));
+          .F_RB_B(f_rb_b)
+          `ifdef KEY
+          ,.KEY(key)
+          `endif 
+          );
 
   flash_a fa(.IO7(f_io_a[7]), 
            .IO6(f_io_a[6]), 
@@ -123,21 +127,21 @@ module test;
       rst = 1'b0;
     `ifdef KEY
     #2
-    key = OFSM_KEY_0
+    key = OFSM_KEY_0;
     #20
-    key = OFSM_KEY_1
+    key = OFSM_KEY_1;
     #20
-    key = OFSM_KEY_2
+    key = OFSM_KEY_2;
     #20
-    key = OFSM_KEY_3
+    key = OFSM_KEY_3;
     #20
-    key = OFSM_KEY_4
+    key = OFSM_KEY_4;
     #20
-    key = OFSM_KEY_5
+    key = OFSM_KEY_5;
     #20
-    key = OFSM_KEY_6
+    key = OFSM_KEY_6;
     #20
-    key = OFSM_KEY_7
+    key = OFSM_KEY_7;
     `endif
   end
 


### PR DESCRIPTION
## __Changes__
### Desc

- Added OFSM
- Need to enter correct KEY to unlock circuit before using it
- KEY is `PYPD` in Hex (`0x50595044`)
- Entering wrong key will cause FSM entering Dummy reigon

### Port
- Add `input [3:0] KEY`
```verilog
module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B, KEY);
    input clk;
    input rst;
    output reg done;

    inout [7:0] F_IO_A;
    output reg F_CLE_A;
    output reg F_ALE_A;
    output reg F_REN_A;
    output reg F_WEN_A;
    input  F_RB_A;

    inout [7:0] F_IO_B;
    output reg F_CLE_B;
    output reg F_ALE_B;
    output reg F_REN_B;
    output reg F_WEN_B;
    input  F_RB_B;

    input [3:0] KEY;
```
### FSM States
```verilog
    /*=============FSM States=============*/
    localparam STATE_READ_COMMAND_0 = 5'd0;
    localparam STATE_READ_COMMAND_1 = 5'd1;
    localparam STATE_READ_ADDRESS_0 = 5'd2;
    localparam STATE_READ_ADDRESS_1 = 5'd3;
    localparam STATE_READ_ADDRESS_2 = 5'd4;
    localparam STATE_READ_ADDRESS_3 = 5'd5;
    localparam STATE_READ_ADDRESS_4 = 5'd6;
    localparam STATE_READ_ADDRESS_5 = 5'd7;
    localparam STATE_READ_READING_0 = 5'd8;
    localparam STATE_READ_READING_1 = 5'd9;
    localparam STATE_READ_BUSYING_0 = 5'd10;
    localparam STATE_READ_BUSYING_1 = 5'd11;
    localparam OBFUS_AUTH_0  = 5'd16;
    localparam OBFUS_AUTH_1  = 5'd17;
    localparam OBFUS_AUTH_2  = 5'd18;
    localparam OBFUS_AUTH_3  = 5'd19;
    localparam OBFUS_AUTH_4  = 5'd20;
    localparam OBFUS_AUTH_5  = 5'd21;
    localparam OBFUS_AUTH_6  = 5'd22;
    localparam OBFUS_AUTH_7  = 5'd23;
    localparam OBFUS_DUMY_0  = 5'd24;
    localparam OBFUS_DUMY_1  = 5'd25;
    localparam OBFUS_DUMY_2  = 5'd26;
    localparam OBFUS_DUMY_3  = 5'd27;
    localparam OBFUS_DUMY_4  = 5'd28;
    localparam OBFUS_DUMY_5  = 5'd29;
    localparam OBFUS_DUMY_6  = 5'd30;
    localparam OBFUS_DUMY_7  = 5'd31;
    /*====================================*/
```
### Testbench
Define `+KEY` to use key.
Example: `ncverilog testfixture.v NFC_KEY.v +define+p1+FSDB+KEY +access+r`
