### PR TITLE
J20020420 TMR/Simplex

### DIFF
--- a/B_ICC2012_preliminary_all_cell/NFC.v
+++ b/B_ICC2012_preliminary_all_cell/NFC.v
@@ -1,357 +1,156 @@
 `timescale 1ns/100ps
-module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B);
-    input clk;
-    input rst;
-    output reg done;
+module NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B, A_error_ctrl, B_error_ctrl, C_error_ctrl, TMR_error);
 
-    inout [7:0] F_IO_A;
-    output reg F_CLE_A;
-    output reg F_ALE_A;
-    output reg F_REN_A;
-    output reg F_WEN_A;
-    input  F_RB_A;
+/*===============original_NFC_copy_A IO===============*/
+input A_error_ctrl,B_error_ctrl,C_error_ctrl;
+output TMR_error;
+wire [26:0] data_A,data_B,data_C;
+wire [26:0] data_out;
 
-    inout [7:0] F_IO_B;
-    output reg F_CLE_B;
-    output reg F_ALE_B;
-    output reg F_REN_B;
-    output reg F_WEN_B;
-    input  F_RB_B;
- 
-    /*========F_IO_A Tristate========*/
-    wire [7:0] F_IO_A_IN;
-    reg  [7:0] F_IO_A_OUT;
-    reg        F_IO_A_READING;
+/*===============original_NFC IO===============*/
+input clk;
+input rst;
+output done;
 
-    assign F_IO_A = F_IO_A_READING ? 8'hZZ : F_IO_A_OUT;
-    // assign F_IO_A_IN = F_IO_A;
-    /*===============================*/
+inout [7:0] F_IO_A;
+wire [7:0] F_IO_A_input;
+wire [7:0] F_IO_A_output;
+output F_CLE_A;
+output F_ALE_A;
+output F_REN_A;
+output F_WEN_A;
+input F_RB_A;
 
+inout [7:0] F_IO_B;
+wire [7:0] F_IO_B_input;
+wire [7:0] F_IO_B_output;
+output F_CLE_B;
+output F_ALE_B;
+output F_REN_B;
+output F_WEN_B;
+input F_RB_B;
 
-    /*========F_IO_B Tristate========*/
-    wire [7:0] F_IO_B_IN;
-    reg  [7:0] F_IO_B_OUT;
-    reg        F_IO_B_READING;
+wire F_IO_A_READING;
+wire F_IO_B_READING;
 
-    assign F_IO_B = F_IO_B_READING ? 8'hZZ : F_IO_B_OUT;
-    // assign F_IO_B_IN = F_IO_B;
-    /*===============================*/
+/*===============original_NFC_copy_A IO===============*/
+wire OA_done;
 
+wire [7:0] OA_F_IO_A;
+wire [7:0] OA_F_IO_A_input;
+wire [7:0] OA_F_IO_A_output;
+wire OA_F_CLE_A;
+wire OA_F_ALE_A;
+wire OA_F_REN_A;
+wire OA_F_WEN_A;
 
-    reg [3:0] state;
-    reg [8:0] page;     //Total of 512 pages, 9 bit.
-    reg [8:0] counter;  //Count 512.
+wire [7:0] OA_F_IO_B;
+wire [7:0] OA_F_IO_B_input;
+wire [7:0] OA_F_IO_B_output;
+wire OA_F_CLE_B;
+wire OA_F_ALE_B;
+wire OA_F_REN_B;
+wire OA_F_WEN_B;
 
-    /*=============FSM States=============*/
-    localparam STATE_READ_COMMAND_0 = 4'd0;
-    localparam STATE_READ_COMMAND_1 = 4'd1;
-    localparam STATE_READ_ADDRESS_0 = 4'd2;
-    localparam STATE_READ_ADDRESS_1 = 4'd3;
-    localparam STATE_READ_ADDRESS_2 = 4'd4;
-    localparam STATE_READ_ADDRESS_3 = 4'd5;
-    localparam STATE_READ_ADDRESS_4 = 4'd6;
-    localparam STATE_READ_ADDRESS_5 = 4'd7;
-    localparam STATE_READ_READING_0 = 4'd8;
-    localparam STATE_READ_READING_1 = 4'd9;
-    localparam STATE_READ_BUSYING_0 = 4'd10;
-    localparam STATE_READ_BUSYING_1 = 4'd11;
-    /*====================================*/
+wire OA_F_IO_A_READING;
+wire OA_F_IO_B_READING;
 
-    always @(posedge clk) begin
-        if (rst) begin
-            done <= 1'b0;
+/*===============original_NFC_copy_B IO===============*/
+wire OB_done;
 
-            F_IO_A_READING <= 1'b0;
-            F_IO_B_READING <= 1'b0;
+wire [7:0] OB_F_IO_A;
+wire [7:0] OB_F_IO_A_input;
+wire [7:0] OB_F_IO_A_output;
+wire OB_F_CLE_A;
+wire OB_F_ALE_A;
+wire OB_F_REN_A;
+wire OB_F_WEN_A;
 
-            state   <= STATE_READ_COMMAND_0;
-            page    <= 9'd0;
-            counter <= 9'd0;
+wire [7:0] OB_F_IO_B;
+wire [7:0] OB_F_IO_B_input;
+wire [7:0] OB_F_IO_B_output;
+wire OB_F_CLE_B;
+wire OB_F_ALE_B;
+wire OB_F_REN_B;
+wire OB_F_WEN_B;
 
-            /*=====A=====*/
-            F_CLE_A <= 1;
-            F_WEN_A <= 0;
-            F_WEN_A <= 0;
-            F_ALE_A <= 0;
-            F_REN_A <= 1;
-            /*===========*/
+wire OB_F_IO_A_READING;
+wire OB_F_IO_B_READING;
 
-            /*=====B=====*/
-            F_CLE_B <= 1;
-            F_WEN_B <= 0;
-            F_ALE_B <= 0;
-            F_REN_B <= 1;
-            /*===========*/
+/*===============original_NFC_copy_C IO===============*/
+wire OC_done;
 
-        end
-        else begin
-            case (state)
-                STATE_READ_COMMAND_0: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 1;
-                    F_WEN_A <= 1;
-                    F_ALE_A <= 0;
-                    F_REN_A <= 1;
-                    /*===========*/
+wire [7:0] OC_F_IO_A;
+wire [7:0] OC_F_IO_A_input;
+wire [7:0] OC_F_IO_A_output;
+wire OC_F_CLE_A;
+wire OC_F_ALE_A;
+wire OC_F_REN_A;
+wire OC_F_WEN_A;
 
-                    /*=====B=====*/
-                    F_CLE_B <= 1;
-                    F_WEN_B <= 1;
-                    F_ALE_B <= 0;
-                    F_REN_B <= 1;
-                    /*===========*/
+wire [7:0] OC_F_IO_B;
+wire [7:0] OC_F_IO_B_input;
+wire [7:0] OC_F_IO_B_output;
+wire OC_F_CLE_B;
+wire OC_F_ALE_B;
+wire OC_F_REN_B;
+wire OC_F_WEN_B;
 
-                    state <= STATE_READ_COMMAND_1;
-                end
-                STATE_READ_COMMAND_1: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 0;
-                    F_ALE_A <= 1;
-                    F_REN_A <= 1;
-                    /*===========*/
+wire OC_F_IO_A_READING;
+wire OC_F_IO_B_READING;
 
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 0;
-                    F_ALE_B <= 1;
-                    F_REN_B <= 1;
-                    /*===========*/
+/*===============Inout data flow===============*/
+assign OA_F_IO_A_input=OA_F_IO_A;
+assign OA_F_IO_A=(!OA_F_IO_A_READING)? 8'hzz:OA_F_IO_A_output;
+assign OA_F_IO_A_output=F_IO_A_input;
+assign OA_F_IO_B_input=OA_F_IO_B;
+assign OA_F_IO_B=(!OA_F_IO_B_READING)? 8'hzz:OA_F_IO_B_output;
+assign OA_F_IO_B_output=F_IO_B_input;
 
-                    state <= STATE_READ_ADDRESS_0;
-                end
-                STATE_READ_ADDRESS_0: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 1;
-                    F_ALE_A <= 1;
-                    F_REN_A <= 1;
-                    /*===========*/
+assign OB_F_IO_A_input=OB_F_IO_A;
+assign OB_F_IO_A=(!OB_F_IO_A_READING)? 8'hzz:OB_F_IO_A_output;
+assign OB_F_IO_A_output=F_IO_A_input;
+assign OB_F_IO_B_input=OB_F_IO_B;
+assign OB_F_IO_B=(!OB_F_IO_B_READING)? 8'hzz:OB_F_IO_B_output;
+assign OB_F_IO_B_output=F_IO_B_input;
 
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 1;
-                    F_ALE_B <= 1;
-                    F_REN_B <= 1;
-                    /*===========*/
+assign OC_F_IO_A_input=OC_F_IO_A;
+assign OC_F_IO_A=(!OC_F_IO_A_READING)? 8'hzz:OC_F_IO_A_output;
+assign OC_F_IO_A_output=F_IO_A_input;
+assign OC_F_IO_B_input=OC_F_IO_B;
+assign OC_F_IO_B=(!OC_F_IO_B_READING)? 8'hzz:OC_F_IO_B_output;
+assign OC_F_IO_B_output=F_IO_B_input;
 
-                    state <= STATE_READ_ADDRESS_1;
-                end
-                STATE_READ_ADDRESS_1: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 0;
-                    F_ALE_A <= 1;
-                    F_REN_A <= 1;
-                    /*===========*/
+assign F_IO_A_input=F_IO_A;
+assign F_IO_A=(F_IO_A_READING)? 8'hzz:F_IO_A_output;
 
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 0;
-                    F_ALE_B <= 1;
-                    F_REN_B <= 1;
-                    /*===========*/
-
-                    state <= STATE_READ_ADDRESS_2;
-                end
-                STATE_READ_ADDRESS_2: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 1;
-                    F_ALE_A <= 1;
-                    F_REN_A <= 1;
-                    /*===========*/
-
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 1;
-                    F_ALE_B <= 1;
-                    F_REN_B <= 1;
-                    /*===========*/
-
-                    state <= STATE_READ_ADDRESS_3;
-                end
-                STATE_READ_ADDRESS_3: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 0;
-                    F_ALE_A <= 1;
-                    F_REN_A <= 1;
-                    /*===========*/
-
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 0;
-                    F_ALE_B <= 1;
-                    F_REN_B <= 1;
-                    /*===========*/
-
-                    state <= STATE_READ_ADDRESS_4;
-                end
-                STATE_READ_ADDRESS_4: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 1;
-                    F_ALE_A <= 1;
-                    F_REN_A <= 1;
-                    /*===========*/
-
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 1;
-                    F_ALE_B <= 1;
-                    F_REN_B <= 1;
-                    /*===========*/
-
-                    state <= STATE_READ_ADDRESS_5;
-                end
-                STATE_READ_ADDRESS_5: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 0;
-                    F_WEN_A <= 1;
-                    F_ALE_A <= 0;
-                    F_REN_A <= 1;
-                    /*===========*/
-
-                    /*=====B=====*/
-                    F_CLE_B <= 0;
-                    F_WEN_B <= 0;
-                    F_ALE_B <= 0;
-                    F_REN_B <= 1;
-                    /*===========*/
-
-                    F_IO_A_READING <= 1;
-                    F_IO_B_READING <= 0;
-
-                    state <= STATE_READ_READING_0;
-                end
-                STATE_READ_READING_0: begin
-                    if (F_RB_A && F_REN_A) begin
-                        F_REN_A <= 0;
-                        F_WEN_B <= 0;
-                    end
-                    else begin
-                        if (F_WEN_B) begin
-                            F_REN_A <= 1;
-                            counter <= counter + 1;
-                            if (counter == 9'd511) begin
-                                F_CLE_A <= 1;
-                                F_WEN_A <= 0;
-                                F_IO_A_READING <= 0;
-                                state <= STATE_READ_READING_1;
-                            end
-                            else begin
-
-                            end
-                        end
-                        else begin
-
-                        end
-                        F_WEN_B <= 1;
-                    end
-                end
-                STATE_READ_READING_1: begin
-                    /*=====A=====*/
-                    F_CLE_A <= 1;
-                    F_WEN_A <= 0;
-                    F_ALE_A <= 0;
-                    F_REN_A <= 1;
-                    /*===========*/
-
-                    /*=====B=====*/
-                    F_CLE_B <= 1;
-                    F_WEN_B <= 0;
-                    F_ALE_B <= 0;
-                    F_REN_B <= 1;
-                    /*===========*/
-
-                    state <= STATE_READ_BUSYING_0;
-                end
-                STATE_READ_BUSYING_0: begin
-                    /*=====B=====*/
-                    F_CLE_B <= 1;
-                    F_WEN_B <= 1;
-                    F_ALE_B <= 0;
-                    F_REN_B <= 1;
-                    /*===========*/
-                    if (!F_RB_B) begin
-                        state <= STATE_READ_BUSYING_1;
-                    end
-                end
-                STATE_READ_BUSYING_1: begin
-                    if (F_RB_B) begin
-                        /*=====B=====*/
-                        F_CLE_B <= 1;
-                        F_WEN_B <= 0;
-                        F_ALE_B <= 0;
-                        F_REN_B <= 1;
-                        /*===========*/
-
-                        page <= page + 1;
-                        if (page == 9'd511) begin
-                            done <= 1;
-                        end
-
-                        state <= STATE_READ_COMMAND_0;
-                    end
-                    else begin
-                        /*=====B=====*/
-                        F_CLE_B <= 0;
-                        F_WEN_B <= 1;
-                        F_ALE_B <= 0;
-                        F_REN_B <= 1;
-                        /*===========*/
-                    end
-                end
-                default: begin
-
-                end
-            endcase
-        end
-    end
+assign F_IO_B_input=F_IO_B;
+assign F_IO_B=(F_IO_B_READING)? 8'hzz:F_IO_B_output;
 
 
-    always @(*) begin
-        if (rst) begin
-            F_IO_A_OUT = 8'h00; //Here we use h00 instead of h01 is because we want to start at first half page.
-            F_IO_B_OUT = 8'h80;
-        end
-        else begin
-            case (state[3:1])
-                STATE_READ_COMMAND_0[3:1]: begin
-                    F_IO_A_OUT = 8'h00;
-                    F_IO_B_OUT = 8'h80;
-                end
-                STATE_READ_ADDRESS_0[3:1]: begin
-                    F_IO_A_OUT = 8'h00;
-                    F_IO_B_OUT = 8'h00;
-                end
-                STATE_READ_ADDRESS_2[3:1]: begin
-                    F_IO_A_OUT = page[7:0];
-                    F_IO_B_OUT = page[7:0];
-                end
-                STATE_READ_ADDRESS_4[3:1]: begin
-                    F_IO_A_OUT = {7'b0, page[8]};
-                    F_IO_B_OUT = {7'b0, page[8]};
-                end
-                STATE_READ_READING_0[3:1]: begin
-                    F_IO_A_OUT = 8'h00;
-                    if (state[0]) begin
-                        F_IO_B_OUT = 8'h10;
-                    end
-                    else begin
-                        F_IO_B_OUT = F_IO_A;
-                    end
-                end
-                STATE_READ_BUSYING_0[3:1]: begin
-                    F_IO_A_OUT = 8'h00;
-                    F_IO_B_OUT = 8'h10;
-                end
-                default: begin
-                    F_IO_A_OUT = 8'hXX;
-                    F_IO_B_OUT = 8'hXX;
-                end
-            endcase
-        end
-    end
-endmodule
+/*===============NFC_TMR IO connection===============*/
+original_NFC OriNFC_A(clk, rst, OA_done, OA_F_IO_A, OA_F_CLE_A, OA_F_ALE_A, OA_F_REN_A, OA_F_WEN_A, F_RB_A, OA_F_IO_B, OA_F_CLE_B, OA_F_ALE_B, OA_F_REN_B, OA_F_WEN_B, F_RB_B, OA_F_IO_A_READING, OA_F_IO_B_READING);
+original_NFC OriNFC_B(clk, rst, OB_done, OB_F_IO_A, OB_F_CLE_A, OB_F_ALE_A, OB_F_REN_A, OB_F_WEN_A, F_RB_A, OB_F_IO_B, OB_F_CLE_B, OB_F_ALE_B, OB_F_REN_B, OB_F_WEN_B, F_RB_B, OB_F_IO_A_READING, OB_F_IO_B_READING);
+original_NFC OriNFC_C(clk, rst, OC_done, OC_F_IO_A, OC_F_CLE_A, OC_F_ALE_A, OC_F_REN_A, OC_F_WEN_A, F_RB_A, OC_F_IO_B, OC_F_CLE_B, OC_F_ALE_B, OC_F_REN_B, OC_F_WEN_B, F_RB_B, OC_F_IO_A_READING, OC_F_IO_B_READING);
+
+assign data_A={OA_done, OA_F_IO_A_input, OA_F_CLE_A, OA_F_ALE_A, OA_F_REN_A, OA_F_WEN_A, OA_F_IO_B_input, OA_F_CLE_B, OA_F_ALE_B, OA_F_REN_B, OA_F_WEN_B, OA_F_IO_A_READING, OA_F_IO_B_READING};
+assign data_B={OB_done, OB_F_IO_A_input, OB_F_CLE_A, OB_F_ALE_A, OB_F_REN_A, OB_F_WEN_A, OB_F_IO_B_input, OB_F_CLE_B, OB_F_ALE_B, OB_F_REN_B, OB_F_WEN_B, OB_F_IO_A_READING, OB_F_IO_B_READING};
+assign data_C={OC_done, OC_F_IO_A_input, OC_F_CLE_A, OC_F_ALE_A, OC_F_REN_A, OC_F_WEN_A, OC_F_IO_B_input, OC_F_CLE_B, OC_F_ALE_B, OC_F_REN_B, OC_F_WEN_B, OC_F_IO_A_READING, OC_F_IO_B_READING};
+
+TMR_Simplex TMR(data_out,TMR_error,data_A,data_B,data_C,A_error_ctrl,B_error_ctrl,C_error_ctrl,clk,rst);
+
+assign done=data_out[26];
+assign F_IO_A_output=data_out[25:18];
+assign F_CLE_A=data_out[17];
+assign F_ALE_A=data_out[16];
+assign F_REN_A=data_out[15];
+assign F_WEN_A=data_out[14];
+assign F_IO_B_output=data_out[13:6];
+assign F_CLE_B=data_out[5];
+assign F_ALE_B=data_out[4];
+assign F_REN_B=data_out[3];
+assign F_WEN_B=data_out[2];
+assign F_IO_A_READING=data_out[1];
+assign F_IO_B_READING=data_out[0];
+
+endmodule 

--- a/B_ICC2012_preliminary_all_cell/TMR_Simplex.v
+++ b/B_ICC2012_preliminary_all_cell/TMR_Simplex.v
@@ -1,0 +1,81 @@
+`timescale 1ns/100ps
+module TMR_Simplex(data_out,TMR_error,dataA_in,dataB_in,dataC_in,A_error_ctrl,B_error_ctrl,C_error_ctrl,clk,reset);
+
+parameter DATA_LEN=5'd27;
+input [DATA_LEN-1'b1:0]dataA_in,dataB_in,dataC_in;
+input A_error_ctrl,B_error_ctrl,C_error_ctrl;
+input clk,reset;
+
+output reg [DATA_LEN-1'b1:0]data_out;
+output reg TMR_error;
+
+wire [DATA_LEN-1'b1:0]_A,_B,_C;
+
+reg A_fault,B_fault,C_fault;
+wire simplex_mode;
+
+assign _A=(A_error_ctrl)? {dataA_in[26:14],8'h55,dataA_in[5:0]}: dataA_in;
+assign _B=(B_error_ctrl)? {dataB_in[26:14],8'h54,dataB_in[5:0]}: dataB_in;
+assign _C=(C_error_ctrl)? {dataC_in[26:14],8'h87,dataC_in[5:0]}: dataC_in;
+
+assign simplex_mode=A_fault|B_fault|C_fault;
+
+always@(*)
+begin
+	if(simplex_mode)
+		if(A_fault)
+		begin
+			data_out=_B;
+			TMR_error=(_B!=_C);
+		end
+		else if(B_fault)
+		begin
+			data_out=_C;
+			TMR_error=(_A!=_C);
+		end
+		else
+		begin
+			data_out=_A;
+			TMR_error=(_A!=_B);
+		end
+	else
+		if((_A!=_B)&&(_A!=_C)&&(_B!=_C))
+		begin
+			data_out=_A;
+			TMR_error=1'b1;
+		end
+		else if((_A!=_B)&&(_A!=_C))
+		begin
+			data_out=_B;
+			TMR_error=1'b0;
+		end
+		else if((_A!=_B)&&(_B!=_C))
+		begin
+			data_out=_C;
+			TMR_error=1'b0;
+		end
+		else 
+		begin
+			data_out=_A;
+			TMR_error=1'b0;
+		end
+	
+end
+
+always@(posedge clk or posedge reset)
+begin
+	if(reset)
+		begin
+			A_fault<=1'b0;
+			B_fault<=1'b0;
+			C_fault<=1'b0;
+		end
+	else
+		begin
+			A_fault<=((_A!=_B)&&(_A!=_C))?1'b1:A_fault;
+			B_fault<=((_A!=_B)&&(_B!=_C))?1'b1:B_fault;
+			C_fault<=((_C!=_B)&&(_A!=_C))?1'b1:C_fault;
+		end
+end
+
+endmodule 

--- a/B_ICC2012_preliminary_all_cell/original_NFC.v
+++ b/B_ICC2012_preliminary_all_cell/original_NFC.v
@@ -1,0 +1,357 @@
+`timescale 1ns/100ps
+module original_NFC(clk, rst, done, F_IO_A, F_CLE_A, F_ALE_A, F_REN_A, F_WEN_A, F_RB_A, F_IO_B, F_CLE_B, F_ALE_B, F_REN_B, F_WEN_B, F_RB_B, F_IO_A_READING, F_IO_B_READING);
+    input clk;
+    input rst;
+    output reg done;
+
+    inout [7:0] F_IO_A;
+    output reg F_CLE_A;
+    output reg F_ALE_A;
+    output reg F_REN_A;
+    output reg F_WEN_A;
+    input  F_RB_A;
+
+    inout [7:0] F_IO_B;
+    output reg F_CLE_B;
+    output reg F_ALE_B;
+    output reg F_REN_B;
+    output reg F_WEN_B;
+    input  F_RB_B;
+ 
+    /*========F_IO_A Tristate========*/
+    wire [7:0] F_IO_A_IN;
+    reg  [7:0] F_IO_A_OUT;
+    output reg        F_IO_A_READING;
+
+    assign F_IO_A = F_IO_A_READING ? 8'hZZ : F_IO_A_OUT;
+    // assign F_IO_A_IN = F_IO_A;
+    /*===============================*/
+
+
+    /*========F_IO_B Tristate========*/
+    wire [7:0] F_IO_B_IN;
+    reg  [7:0] F_IO_B_OUT;
+    output reg        F_IO_B_READING;
+
+    assign F_IO_B = F_IO_B_READING ? 8'hZZ : F_IO_B_OUT;
+    // assign F_IO_B_IN = F_IO_B;
+    /*===============================*/
+
+
+    reg [3:0] state;
+    reg [8:0] page;     //Total of 512 pages, 9 bit.
+    reg [8:0] counter;  //Count 512.
+
+    /*=============FSM States=============*/
+    localparam STATE_READ_COMMAND_0 = 4'd0;
+    localparam STATE_READ_COMMAND_1 = 4'd1;
+    localparam STATE_READ_ADDRESS_0 = 4'd2;
+    localparam STATE_READ_ADDRESS_1 = 4'd3;
+    localparam STATE_READ_ADDRESS_2 = 4'd4;
+    localparam STATE_READ_ADDRESS_3 = 4'd5;
+    localparam STATE_READ_ADDRESS_4 = 4'd6;
+    localparam STATE_READ_ADDRESS_5 = 4'd7;
+    localparam STATE_READ_READING_0 = 4'd8;
+    localparam STATE_READ_READING_1 = 4'd9;
+    localparam STATE_READ_BUSYING_0 = 4'd10;
+    localparam STATE_READ_BUSYING_1 = 4'd11;
+    /*====================================*/
+
+    always @(posedge clk) begin
+        if (rst) begin
+            done <= 1'b0;
+
+            F_IO_A_READING <= 1'b0;
+            F_IO_B_READING <= 1'b0;
+
+            state   <= STATE_READ_COMMAND_0;
+            page    <= 9'd0;
+            counter <= 9'd0;
+
+            /*=====A=====*/
+            F_CLE_A <= 1;
+            F_WEN_A <= 0;
+            F_WEN_A <= 0;
+            F_ALE_A <= 0;
+            F_REN_A <= 1;
+            /*===========*/
+
+            /*=====B=====*/
+            F_CLE_B <= 1;
+            F_WEN_B <= 0;
+            F_ALE_B <= 0;
+            F_REN_B <= 1;
+            /*===========*/
+
+        end
+        else begin
+            case (state)
+                STATE_READ_COMMAND_0: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 1;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 0;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_COMMAND_1;
+                end
+                STATE_READ_COMMAND_1: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_0;
+                end
+                STATE_READ_ADDRESS_0: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_1;
+                end
+                STATE_READ_ADDRESS_1: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_2;
+                end
+                STATE_READ_ADDRESS_2: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_3;
+                end
+                STATE_READ_ADDRESS_3: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_4;
+                end
+                STATE_READ_ADDRESS_4: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 1;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 1;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_ADDRESS_5;
+                end
+                STATE_READ_ADDRESS_5: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 0;
+                    F_WEN_A <= 1;
+                    F_ALE_A <= 0;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 0;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    F_IO_A_READING <= 1;
+                    F_IO_B_READING <= 0;
+
+                    state <= STATE_READ_READING_0;
+                end
+                STATE_READ_READING_0: begin
+                    if (F_RB_A && F_REN_A) begin
+                        F_REN_A <= 0;
+                        F_WEN_B <= 0;
+                    end
+                    else begin
+                        if (F_WEN_B) begin
+                            F_REN_A <= 1;
+                            counter <= counter + 1;
+                            if (counter == 9'd511) begin
+                                F_CLE_A <= 1;
+                                F_WEN_A <= 0;
+                                F_IO_A_READING <= 0;
+                                state <= STATE_READ_READING_1;
+                            end
+                            else begin
+
+                            end
+                        end
+                        else begin
+
+                        end
+                        F_WEN_B <= 1;
+                    end
+                end
+                STATE_READ_READING_1: begin
+                    /*=====A=====*/
+                    F_CLE_A <= 1;
+                    F_WEN_A <= 0;
+                    F_ALE_A <= 0;
+                    F_REN_A <= 1;
+                    /*===========*/
+
+                    /*=====B=====*/
+                    F_CLE_B <= 1;
+                    F_WEN_B <= 0;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+
+                    state <= STATE_READ_BUSYING_0;
+                end
+                STATE_READ_BUSYING_0: begin
+                    /*=====B=====*/
+                    F_CLE_B <= 1;
+                    F_WEN_B <= 1;
+                    F_ALE_B <= 0;
+                    F_REN_B <= 1;
+                    /*===========*/
+                    if (!F_RB_B) begin
+                        state <= STATE_READ_BUSYING_1;
+                    end
+                end
+                STATE_READ_BUSYING_1: begin
+                    if (F_RB_B) begin
+                        /*=====B=====*/
+                        F_CLE_B <= 1;
+                        F_WEN_B <= 0;
+                        F_ALE_B <= 0;
+                        F_REN_B <= 1;
+                        /*===========*/
+
+                        page <= page + 1;
+                        if (page == 9'd511) begin
+                            done <= 1;
+                        end
+
+                        state <= STATE_READ_COMMAND_0;
+                    end
+                    else begin
+                        /*=====B=====*/
+                        F_CLE_B <= 0;
+                        F_WEN_B <= 1;
+                        F_ALE_B <= 0;
+                        F_REN_B <= 1;
+                        /*===========*/
+                    end
+                end
+                default: begin
+
+                end
+            endcase
+        end
+    end
+
+
+    always @(*) begin
+        if (rst) begin
+            F_IO_A_OUT = 8'h00; //Here we use h00 instead of h01 is because we want to start at first half page.
+            F_IO_B_OUT = 8'h80;
+        end
+        else begin
+            case (state[3:1])
+                STATE_READ_COMMAND_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    F_IO_B_OUT = 8'h80;
+                end
+                STATE_READ_ADDRESS_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    F_IO_B_OUT = 8'h00;
+                end
+                STATE_READ_ADDRESS_2[3:1]: begin
+                    F_IO_A_OUT = page[7:0];
+                    F_IO_B_OUT = page[7:0];
+                end
+                STATE_READ_ADDRESS_4[3:1]: begin
+                    F_IO_A_OUT = {7'b0, page[8]};
+                    F_IO_B_OUT = {7'b0, page[8]};
+                end
+                STATE_READ_READING_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    if (state[0]) begin
+                        F_IO_B_OUT = 8'h10;
+                    end
+                    else begin
+                        F_IO_B_OUT = F_IO_A;
+                    end
+                end
+                STATE_READ_BUSYING_0[3:1]: begin
+                    F_IO_A_OUT = 8'h00;
+                    F_IO_B_OUT = 8'h10;
+                end
+                default: begin
+                    F_IO_A_OUT = 8'hXX;
+                    F_IO_B_OUT = 8'hXX;
+                end
+            endcase
+        end
+    end
+endmodule

--- a/B_ICC2012_preliminary_all_cell/testfixture.v
+++ b/B_ICC2012_preliminary_all_cell/testfixture.v
@@ -23,11 +23,15 @@ module test;
 
   reg  clk, rst;
   wire done;
+  wire r1,r2;
   wire [7:0] f_io_a;
   wire f_cle_a, f_ale_a, f_ren_a, f_wen_a, f_rb_a;
   wire [7:0] f_io_b;
   wire f_cle_b, f_ale_b, f_ren_b, f_wen_b, f_rb_b;
   integer  out_mem [0:262143]; 
+  
+  wire TMR_error;
+  reg a_ctrl,b_ctrl,c_ctrl;
   
   reg [18:0] k;
   reg [8:0] x;
@@ -49,7 +53,11 @@ module test;
           .F_ALE_B(f_ale_b), 
           .F_REN_B(f_ren_b), 
           .F_WEN_B(f_wen_b), 
-          .F_RB_B(f_rb_b));
+          .F_RB_B(f_rb_b),
+		  .A_error_ctrl(a_ctrl),
+		  .B_error_ctrl(b_ctrl),
+		  .C_error_ctrl(c_ctrl),
+		  .TMR_error(TMR_error));
 
   flash_a fa(.IO7(f_io_a[7]), 
            .IO6(f_io_a[6]), 
@@ -96,6 +104,11 @@ module test;
   end
 
   initial begin
+  
+	a_ctrl=0;
+	b_ctrl=0;
+	c_ctrl=0;
+  
     clk = 1'b0;
     rst = 1'b0;
     n = 0;
@@ -104,6 +117,10 @@ module test;
       rst = 1'b1;
     #15
       rst = 1'b0;
+	  
+	//#50000 a_ctrl=1'b1;
+	//#50000 b_ctrl=1'b1;
+	//#3000 c_ctrl=1'b1;
   end
 
   always #duty clk = ~clk;
@@ -133,11 +150,17 @@ begin
 	if (err == 0)  begin
 	            $display("All data have been generated successfully!\n");
 	            $display("-------------------PASS-------------------\n");
+				
+				$display("TMR error=%b \n",TMR_error);
+				
 		    $finish;
 	         end
 	         else begin
 	            $display("There are %d errors!\n", err);
 	            $display("---------------------------------------------\n");
+				
+				$display("TMR error=%b \n",TMR_error);
+				
 		    $finish;
          	      end
 	

--- a/TMR功能.txt
+++ b/TMR功能.txt
@@ -1,0 +1,20 @@
+TMR_Simplex
+
+簡介
+我將原本的NFC(沒有watermark的那個)拉出F_IO_A_READING和F_IO_B_READING並加裝TMR_Simplex
+
+使用注意事項
+1. 要整合時記得將原本的NFC改名成original_NFC
+2. 少的IO(如key)請自己補
+3. 並拉出F_IO_A_READING和F_IO_B_READING到output
+4. TMR_Simplex.v、original_NFC.v、NFC.v要在同個資料夾
+
+多的IO(都加在module的最後面)
+A_error_ctrl(input): 為1時三塊original_NFC中A copy的輸出會發生錯誤，為0則正常運作(測試用input)
+B_error_ctrl(input): 為1時三塊original_NFC中B copy的輸出會發生錯誤，為0則正常運作(測試用input)
+C_error_ctrl(input): 為1時三塊original_NFC中C copy的輸出會發生錯誤，為0則正常運作(測試用input)
+TMR_error(output): 當兩塊以上的original_NFC發生錯誤時為1，否則為0
+
+正常輸出或狀況
+**如果沒錯或一個錯則PASS且TMR_error=0
+**否則卡住、沒全PASS或TMR_error=1


### PR DESCRIPTION
TMR_Simplex

簡介
我將原本的NFC(沒有watermark的那個)拉出F_IO_A_READING和F_IO_B_READING並加裝TMR_Simplex

使用注意事項
1. 要整合時記得將原本的NFC改名成original_NFC
2. 少的IO(如key)請自己補
3. 並拉出F_IO_A_READING和F_IO_B_READING到output
4. TMR_Simplex.v、original_NFC.v、NFC.v要在同個資料夾

多的IO(都加在module的最後面)
A_error_ctrl(input): 為1時三塊original_NFC中A copy的輸出會發生錯誤，為0則正常運作(測試用input)
B_error_ctrl(input): 為1時三塊original_NFC中B copy的輸出會發生錯誤，為0則正常運作(測試用input)
C_error_ctrl(input): 為1時三塊original_NFC中C copy的輸出會發生錯誤，為0則正常運作(測試用input)
TMR_error(output): 當兩塊以上的original_NFC發生錯誤時為1，否則為0

正常輸出或狀況
**如果沒錯或一個錯則PASS且TMR_error=0
**否則卡住、沒全PASS或TMR_error=1